### PR TITLE
Added Navigation to __all__ exports and update catalog functions

### DIFF
--- a/opds2/__init__.py
+++ b/opds2/__init__.py
@@ -12,16 +12,20 @@ from opds2.models import (
     Contributor,
     Link,
     Metadata,
+    Navigation,
     Publication,
 )
 from opds2.provider import DataProvider, DataProviderRecord
 
 __all__ = [
+    "create_catalog",
+    "create_search_catalog",
     "Catalog",
     "Contributor",
     "DataProvider",
     "DataProviderRecord",
     "Link",
     "Metadata",
+    "Navigation",
     "Publication",
 ]


### PR DESCRIPTION
@mekarpeles @cdrini 
### issue: 
The package-level API in __init__.py didn’t expose several key helpers: `create_catalog`, `create_search_catalog`, and the `Navigation` model even though the package imported them. As a result, users couldn’t access those OPDS 2.0 helpers via `from opds2 import ...`

### fix:
- Exported the catalog helpers (`create_catalog`, `create_search_catalog`) and `Navigation` from __init__.py so they’re available at package level.  
- Keeps the public API aligned with the OPDS 2.0 helpers already implemented.  
- Test suite (`pytest`) still passes.

### Test results
<img width="773" height="181" alt="Screenshot 2025-10-25 at 4 26 25 AM" src="https://github.com/user-attachments/assets/7d26aea8-c4eb-43c6-b4b1-6c2c88f0fdd8" />
