### PR TITLE
Allow search to specify optional metadata.title

### DIFF
--- a/pyopds2/models.py
+++ b/pyopds2/models.py
@@ -213,7 +213,8 @@ class Catalog(BaseModel):
             response: Optional SearchResponse for paginated search results
             paginate: Whether to add pagination links (requires data)
         """
-        metadata = metadata or Metadata(title="OPDS Catalog")
+        if not metadata:
+            metadata = Metadata(title=response.title or "OPDS Catalog")
         links = links or []
         publications = publications or []
 

--- a/pyopds2/provider.py
+++ b/pyopds2/provider.py
@@ -76,6 +76,7 @@ class DataProvider(ABC):
         sort: Optional[str]
         records: List[DataProviderRecord]
         total: int
+        title: Optional[str] = None
 
         def get_search_url(self, **kwargs: str) -> str:
             base_url = self.provider.SEARCH_URL.replace("{?query}", "")
@@ -118,6 +119,7 @@ class DataProvider(ABC):
         limit: int = 50,
         offset: int = 0,
         sort: Optional[str] = None,
+        title: Optional[str] = None,
     ) -> 'DataProvider.SearchResponse':
         """Search for publications matching the query.
 
@@ -126,6 +128,7 @@ class DataProvider(ABC):
             limit: Maximum number of results to return (default: 50)
             offset: Offset for pagination (default: 0)
             sort: Optional sorting parameter
+            title: Title to pass along to Catalog.create
 
         Returns:
             SearchResponse object containing search results
@@ -137,5 +140,6 @@ class DataProvider(ABC):
             query=query,
             limit=limit,
             offset=offset,
-            sort=sort
+            sort=sort,
+            title=title,
         )


### PR DESCRIPTION
This pull request enhances the search functionality in the OPDS2 provider by allowing a custom title to be passed through the search process and included in the search response. This improves the flexibility of catalog generation and enables more descriptive search result pages.

**Enhancements to search functionality:**

* Added an optional `title` parameter to the `search` method in `DataProvider`, allowing callers to specify a custom title for search results. [[1]](diffhunk://#diff-3c4eb5693ca60f8c4cdee0fb8a7c7df6abf3722fd9954166b46f92a6e27ec8b0R122) [[2]](diffhunk://#diff-3c4eb5693ca60f8c4cdee0fb8a7c7df6abf3722fd9954166b46f92a6e27ec8b0R131)
* Updated the `SearchResponse` class to include a `title` attribute, ensuring the title is available in the search response.
* Modified the call to `Catalog.create` within the `search` method to pass the new `title` parameter.

**Catalog creation improvements:**

* Updated the `Catalog.create` method to use the provided `response.title` as the default catalog title if no metadata is supplied, resulting in more meaningful catalog titles for search results.